### PR TITLE
Trigger ActiveCampaign sync when assessment generation completes

### DIFF
--- a/includes/class-jeanius-ai.php
+++ b/includes/class-jeanius-ai.php
@@ -357,7 +357,7 @@ class JeaniusAI {
                 "## College Essay Topics\n$essay_md";
                 
         update_field('jeanius_report_md', $full, $post_id);
-        
+
         // Clean up temporary data
         delete_post_meta($post_id, '_jeanius_stakes');
         delete_post_meta($post_id, '_jeanius_life_messages');
@@ -365,6 +365,9 @@ class JeaniusAI {
         delete_post_meta($post_id, '_jeanius_summary');
         delete_post_meta($post_id, '_jeanius_summary_formatted');
         delete_post_meta($post_id, '_jeanius_generation_errors');
+
+        // Allow additional tasks (PDF generation, ActiveCampaign sync, etc.)
+        \do_action('jeanius_assessment_generated', $post_id);
     }
     
     /**

--- a/includes/extra-functions.php
+++ b/includes/extra-functions.php
@@ -1480,18 +1480,6 @@ function send_results_pdf_from_dom()
         return;
     }
     
-    // SEND TAGS TO ACTIVE CAMPAIGN
-    // This is the new code to tag contacts in ActiveCampaign
-    jeanius_send_activecampaign_tags($current_user->user_email, $parent_email, $post_id);
-    
-    // Send PDF URL to ActiveCampaign for student only
-    if ($attach_id) {
-        $pdf_url = wp_get_attachment_url($attach_id);
-        if ($pdf_url) {
-            jeanius_send_pdf_to_activecampaign($current_user->user_email, $pdf_url);
-        }
-    }
-    
     if ($sent) {
         $response = array(
             "message" => "PDF emailed successfully!",


### PR DESCRIPTION
## Summary
- fire the `jeanius_assessment_generated` hook when the Jeanius AI pipeline finalises so downstream automation can run immediately after the report is built
- stop the front-end "Send PDF" AJAX handler from pushing ActiveCampaign tags or URLs, leaving it to just send the email because the automation now runs on generation completion

## Testing
- php -l includes/class-jeanius-ai.php
- php -l includes/extra-functions.php

------
https://chatgpt.com/codex/tasks/task_b_68cc31ac97f08331937fddacf49031af