### PR TITLE
Trigger assessment automation when results page loads

### DIFF
--- a/includes/class-jeanius-ai.php
+++ b/includes/class-jeanius-ai.php
@@ -88,6 +88,8 @@ class JeaniusAI {
         delete_post_meta($post_id, '_jeanius_generation_errors');
         delete_post_meta($post_id, '_jeanius_generation_started');
         delete_post_meta($post_id, '_jeanius_generation_last_activity');
+        delete_post_meta($post_id, '_jeanius_assessment_generated_pending');
+        delete_post_meta($post_id, '_jeanius_assessment_generated_at');
         
         // Also delete temporary data from previous attempts
         delete_post_meta($post_id, '_jeanius_stakes');
@@ -357,7 +359,7 @@ class JeaniusAI {
                 "## College Essay Topics\n$essay_md";
                 
         update_field('jeanius_report_md', $full, $post_id);
-        
+
         // Clean up temporary data
         delete_post_meta($post_id, '_jeanius_stakes');
         delete_post_meta($post_id, '_jeanius_life_messages');
@@ -365,6 +367,10 @@ class JeaniusAI {
         delete_post_meta($post_id, '_jeanius_summary');
         delete_post_meta($post_id, '_jeanius_summary_formatted');
         delete_post_meta($post_id, '_jeanius_generation_errors');
+
+        // Flag that downstream automation should run when the results page is viewed
+        update_post_meta($post_id, '_jeanius_assessment_generated_pending', '1');
+        delete_post_meta($post_id, '_jeanius_assessment_generated_at');
     }
     
     /**

--- a/includes/class-jeanius-wizard-page.php
+++ b/includes/class-jeanius-wizard-page.php
@@ -1810,8 +1810,20 @@ public static function render_results() {
 		'College Essay Topics' => get_field( 'essay_topics_md_copy',         $post_id ),
 	];
 
-	$is_ready   = array_filter( $sections ) !== [];      // any HTML present?
-	$rest_nonce = wp_create_nonce( 'wp_rest' );
+        $is_ready   = array_filter( $sections ) !== [];      // any HTML present?
+
+        if ( $is_ready ) {
+                $pending_flag = get_post_meta( $post_id, '_jeanius_assessment_generated_pending', true );
+                $already_ran  = get_post_meta( $post_id, '_jeanius_assessment_generated_at', true );
+
+                if ( $pending_flag || ( '' === $pending_flag && '' === $already_ran ) ) {
+                        do_action( 'jeanius_assessment_generated', $post_id );
+                        delete_post_meta( $post_id, '_jeanius_assessment_generated_pending' );
+                        update_post_meta( $post_id, '_jeanius_assessment_generated_at', current_time( 'timestamp' ) );
+                }
+        }
+
+        $rest_nonce = wp_create_nonce( 'wp_rest' );
 	?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>


### PR DESCRIPTION
## Summary
- flag completed assessments as pending frontend automation and clear that marker when a generation reset starts
- trigger `jeanius_assessment_generated` from the results template once the rendered report is available, then record that it has run
- ensure manual regeneration clears the automation flags so the hook can fire again after the refreshed report is viewed

## Testing
- php -l includes/class-jeanius-ai.php
- php -l includes/class-jeanius-wizard-page.php
- php -l includes/extra-functions.php

------
https://chatgpt.com/codex/tasks/task_b_68cc31ac97f08331937fddacf49031af